### PR TITLE
Increase TCP max line length to 99990

### DIFF
--- a/syslog/drainer.go
+++ b/syslog/drainer.go
@@ -37,7 +37,7 @@ func NewDrainer(drain Drain, hostname string) (*drainer, error) {
 			nil,
 			30*time.Second,
 			30*time.Second,
-			9990,
+			99990,
 		)
 
 		if err != nil {


### PR DESCRIPTION
We want to be able to send longer log messages than ~10k.

Also this seems like a typo as in the used library the default value is 99990. [1]

[1] https://github.com/papertrail/remote_syslog2/blob/bb588fe75acc16fc38c5d66c9d365aff9c911129/config.go#L82