### PR TITLE
Include filename in logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ syslog:
     address: logs.example.com:1234
 
   source_dir: /path/to/log-dir
+  log_filename: false
 ```
 
 Consider the case where `log-dir` has the following structure:
@@ -39,6 +40,8 @@ Consider the case where `log-dir` has the following structure:
 ```
 
 Any new lines written to `app1/stdout.log` and `app1/stderr.log` get sent to syslog tagged as `app1`, while new lines written to `app2/foo.log` and `app2/bar.log` get sent to syslog tagged as `app2`.
+
+If `log_filename` is set to `true` then the filename is included in the tag. For example, new lines written to `app1/stdout.log` get sent to syslog tagged as `app1/stdout.log`.
 
 Currently the priority and facility are hardcoded to `INFO` and `user`.
 

--- a/cmd/blackbox/main.go
+++ b/cmd/blackbox/main.go
@@ -36,7 +36,7 @@ func main() {
 	running := ifrit.Invoke(sigmon.New(group))
 
 	go func() {
-		fileWatcher := blackbox.NewFileWatcher(logger, config.Syslog.SourceDir, group.Client(), config.Syslog.Destination, config.Hostname, config.StructuredData, config.Syslog.ExcludeFilePattern)
+		fileWatcher := blackbox.NewFileWatcher(logger, config.Syslog.SourceDir, config.Syslog.LogFilename, group.Client(), config.Syslog.Destination, config.Hostname, config.StructuredData, config.Syslog.ExcludeFilePattern)
 		fileWatcher.Watch()
 	}()
 

--- a/config.go
+++ b/config.go
@@ -4,14 +4,15 @@ import (
 	"io/ioutil"
 	"os"
 
+	yaml "github.com/bosh-tools/bosh-ext-cli/src/gopkg.in/yaml.v2"
 	"github.com/cloudfoundry/blackbox/syslog"
-	"gopkg.in/yaml.v2"
 )
 
 type SyslogConfig struct {
 	Destination        syslog.Drain `yaml:"destination"`
 	SourceDir          string       `yaml:"source_dir"`
 	ExcludeFilePattern string       `yaml:"exclude_file_pattern"`
+	LogFilename        bool         `yaml:"log_filename"`
 }
 
 type Config struct {

--- a/integration/syslog_test.go
+++ b/integration/syslog_test.go
@@ -110,6 +110,24 @@ var _ = Describe("Blackbox", func() {
 			blackboxRunner.Stop()
 		})
 
+		Context("when logging with filename is activated", func() {
+			It("logs with <subdirectory>/<filename> as tag", func() {
+				config := buildConfig(logDir)
+				config.Syslog.LogFilename = true
+				blackboxRunner.StartWithConfig(config, 1)
+
+				logFile.WriteString("hello\n")
+				logFile.Sync()
+				logFile.Close()
+
+				var message *sl.Message
+				Eventually(inbox.Messages, "5s").Should(Receive(&message))
+				Expect(message.Content).To(ContainSubstring("test-tag/tail.log"))
+
+				blackboxRunner.Stop()
+			})
+		})
+
 		It("can have a custom hostname", func() {
 			config := buildConfig(logDir)
 			config.Hostname = "fake-hostname"


### PR DESCRIPTION
Follow-up to this issue: https://github.com/cloudfoundry/blackbox/issues/5#issuecomment-405417287

This PR adds the option to include the log filename as a tag.

As default the tag equals the subdirectories of a logfile.
This change adds the optional config parameter `log_filename`. If set to
true the tag will also include the log-filename.

Also we now validate that the tag name(=app-name) does not violate the constraints in length or characters formulated in https://tools.ietf.org/html/rfc5424#section-6. 

Related story:
https://www.pivotaltracker.com/story/show/159100361
