### PR TITLE
Exclude files for windows

### DIFF
--- a/cmd/blackbox/main.go
+++ b/cmd/blackbox/main.go
@@ -36,7 +36,7 @@ func main() {
 	running := ifrit.Invoke(sigmon.New(group))
 
 	go func() {
-		fileWatcher := blackbox.NewFileWatcher(logger, config.Syslog.SourceDir, group.Client(), config.Syslog.Destination, config.Hostname, config.StructuredData)
+		fileWatcher := blackbox.NewFileWatcher(logger, config.Syslog.SourceDir, group.Client(), config.Syslog.Destination, config.Hostname, config.StructuredData, config.Syslog.ExcludeFilePattern)
 		fileWatcher.Watch()
 	}()
 

--- a/config.go
+++ b/config.go
@@ -9,8 +9,9 @@ import (
 )
 
 type SyslogConfig struct {
-	Destination syslog.Drain `yaml:"destination"`
-	SourceDir   string       `yaml:"source_dir"`
+	Destination        syslog.Drain `yaml:"destination"`
+	SourceDir          string       `yaml:"source_dir"`
+	ExcludeFilePattern string       `yaml:"exclude_file_pattern"`
 }
 
 type Config struct {

--- a/file_watcher.go
+++ b/file_watcher.go
@@ -78,7 +78,6 @@ func (f *fileWatcher) findLogsToWatch(tag string, filePath string, file os.FileI
 	if !file.IsDir() {
 		if strings.HasSuffix(file.Name(), ".log") {
 			if matched, _ := filepath.Match(f.excludeFilePattern, file.Name()); matched {
-				f.logger.Printf("skipping log file '%s' excluded by glob: %s\n", file.Name(), f.excludeFilePattern)
 				return
 			}
 			if _, found := f.dynamicGroupClient.Get(filePath); !found {

--- a/integration/syslog_test.go
+++ b/integration/syslog_test.go
@@ -77,7 +77,8 @@ var _ = Describe("Blackbox", func() {
 						Transport: "udp",
 						Address:   syslogServer.Addr,
 					},
-					SourceDir: dirToWatch,
+					SourceDir:          dirToWatch,
+					ExcludeFilePattern: "*[0-9].log",
 				},
 			}
 		}
@@ -202,6 +203,51 @@ var _ = Describe("Blackbox", func() {
 			Expect(err).NotTo(HaveOccurred())
 			defer anotherLogFile.Close()
 			notALogFile, err := os.OpenFile(filepath.Join(logDir, tagName, "not-a-log-file.log.1"), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.ModePerm)
+			Expect(err).NotTo(HaveOccurred())
+			defer notALogFile.Close()
+
+			config := buildConfig(logDir)
+			blackboxRunner.StartWithConfig(config, 2)
+
+			logFile.WriteString("hello\n")
+			logFile.Sync()
+
+			notALogFile.WriteString("john cena\n")
+			notALogFile.Sync()
+
+			var message *sl.Message
+			Eventually(inbox.Messages, "30s").Should(Receive(&message))
+			Expect(message.Content).To(ContainSubstring("hello"))
+			Expect(message.Content).To(ContainSubstring("test-tag"))
+			Expect(message.Content).To(ContainSubstring(Hostname()))
+
+			Consistently(inbox.Messages).ShouldNot(Receive())
+
+			anotherLogFile.WriteString("hello from the other side\n")
+			anotherLogFile.Sync()
+
+			notALogFile.WriteString("my time is now\n")
+			notALogFile.Sync()
+
+			Eventually(inbox.Messages, "5s").Should(Receive(&message))
+			Expect(message.Content).To(ContainSubstring("hello from the other side"))
+			Expect(message.Content).To(ContainSubstring("test-tag"))
+			Expect(message.Content).To(ContainSubstring(Hostname()))
+
+			Consistently(inbox.Messages).ShouldNot(Receive())
+
+			blackboxRunner.Stop()
+		})
+
+		It("skips files matching exclude_file_pattern", func() {
+			anotherLogFile, err := os.OpenFile(
+				filepath.Join(logDir, tagName, "another-tail.log"),
+				os.O_WRONLY|os.O_CREATE|os.O_TRUNC,
+				os.ModePerm,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			defer anotherLogFile.Close()
+			notALogFile, err := os.OpenFile(filepath.Join(logDir, tagName, "excluded.1.log"), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.ModePerm)
 			Expect(err).NotTo(HaveOccurred())
 			defer notALogFile.Close()
 

--- a/integration/syslog_test.go
+++ b/integration/syslog_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Blackbox", func() {
 						Address:   syslogServer.Addr,
 					},
 					SourceDir:          dirToWatch,
-					ExcludeFilePattern: "*[0-9].log",
+					ExcludeFilePattern: "*.[0-9].log",
 				},
 			}
 		}


### PR DESCRIPTION
We found that on Windows, blackbox will try to tail the rotated log files that have names like
job-service-wrapper.0.out.log, resulting in duplicate log lines in the syslog sink.

This PR gives us the ability to specify a pattern of files to exclude, such as .[0-9]..log

We will send a corresponding PR to windows-syslog-release that sets this property.

Tracker story: #161665842