### PR TITLE
Remove dependency to bosh-ext-cli

### DIFF
--- a/config.go
+++ b/config.go
@@ -4,8 +4,8 @@ import (
 	"io/ioutil"
 	"os"
 
-	yaml "github.com/bosh-tools/bosh-ext-cli/src/gopkg.in/yaml.v2"
 	"github.com/cloudfoundry/blackbox/syslog"
+	"gopkg.in/yaml.v2"
 )
 
 type SyslogConfig struct {


### PR DESCRIPTION
Seems that this dependency to bosh-ext-cli came accidentally in with https://github.com/cloudfoundry/blackbox/pull/7.

[#159100361](https://www.pivotaltracker.com/story/show/159100361)