### PR TITLE
Add option for RFC3339 log format

### DIFF
--- a/config.go
+++ b/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	Hostname       string       `yaml:"hostname"`
 	StructuredData string       `yaml:"structured_data"`
 	Syslog         SyslogConfig `yaml:"syslog"`
+	UseRFC3339     bool         `yaml:"use_rfc3339"`
 }
 
 func LoadConfig(path string) (*Config, error) {

--- a/file_watcher.go
+++ b/file_watcher.go
@@ -116,6 +116,7 @@ func (f *fileWatcher) memberForFile(logfilePath string) grouper.Member {
 		Path:    logfilePath,
 		Tag:     tag,
 		Drainer: drainer,
+		Logger:  f.logger,
 	}
 
 	return grouper.Member{tailer.Path, tailer}

--- a/tailer.go
+++ b/tailer.go
@@ -15,6 +15,7 @@ type Tailer struct {
 	Path    string
 	Tag     string
 	Drainer syslog.Drainer
+	Logger  *log.Logger
 }
 
 func (tailer *Tailer) Run(signals <-chan os.Signal, ready chan<- struct{}) error {
@@ -28,6 +29,7 @@ func (tailer *Tailer) Run(signals <-chan os.Signal, ready chan<- struct{}) error
 			Offset: 0,
 			Whence: os.SEEK_END,
 		},
+		Logger: tailer.Logger,
 	})
 
 	if err != nil {


### PR DESCRIPTION
blockbox config should now support RFC3339 log format.

e.g.:

```yaml
hostname: xyz
use_rfc3339: true #(defaults to false)
```