### PR TITLE
feat: add configurable retries with exponential backoff

### DIFF
--- a/integration/blackbox.go
+++ b/integration/blackbox.go
@@ -95,7 +95,7 @@ func (runner *BlackboxRunner) StartWithConfig(config blackbox.Config, tailerCoun
 			Name:          "blackbox",
 			Command:       blackboxCmd,
 			AnsiColorCode: "90m",
-			StartCheck:    "Start tail...",
+			StartCheck:    "Starting to tail file:",
 			Cleanup: func() {
 				os.Remove(configPath)
 			},

--- a/tailer.go
+++ b/tailer.go
@@ -23,7 +23,7 @@ type Tailer struct {
 func (tailer *Tailer) Run(signals <-chan os.Signal, ready chan<- struct{}) error {
 	watch.POLL_DURATION = 1 * time.Second
 
-	tailer.Logger.Printf("Start tail...")
+	tailer.Logger.Printf("Starting to tail file: %s", tailer.Path)
 	t, err := tail.TailFile(tailer.Path, tail.Config{
 		Follow: true,
 		ReOpen: true,


### PR DESCRIPTION
# Description

On windows blackbox was preventing log rotation when configured with invalid syslog credentials as it was locking the file while trying to endlessly reconnect. This change makes it so that blackbox exits which unlocks the file and indicates that the config is invalid.
- blackbox now exits when it runs out of retries
- default behavior does not change, configure max_retries to enable

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [x] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [x] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
