### PR TITLE
Constant delay between reconnection attempts

### DIFF
--- a/integration/syslog_test.go
+++ b/integration/syslog_test.go
@@ -627,7 +627,7 @@ var _ = Describe("Blackbox", func() {
 			session, err := gexec.Start(blackboxCmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
 
-			time.Sleep(2 * syslog.ServerPollingInterval)
+			time.Sleep(2 * time.Second)
 
 			buffer := gbytes.NewBuffer()
 			serverProcess = ginkgomon.Invoke(&TcpSyslogServer{
@@ -648,7 +648,10 @@ var _ = Describe("Blackbox", func() {
 			Write(logFile, "can't log this\n", false, false)
 			Write(logFile, "more\n", true, true)
 
-			time.Sleep(2 * syslog.ServerPollingInterval)
+			Eventually(session.Err, "5s").Should(gbytes.Say("Error connecting.*Will retry in 1 seconds"))
+			Eventually(session.Err, "5s").Should(gbytes.Say("Error connecting.*Will retry in 1 seconds"))
+
+			time.Sleep(2 * time.Second)
 
 			buffer2 := gbytes.NewBuffer()
 			serverProcess = ginkgomon.Invoke(&TcpSyslogServer{
@@ -790,6 +793,9 @@ var _ = Describe("Blackbox", func() {
 
 				Write(logFile, "try to log this\n", false, false)
 				Write(logFile, "try to log more and notice can't write to socket\n", true, true)
+
+				Eventually(session.Err, "5s").Should(gbytes.Say("Error connecting.*Will retry in 2 seconds"))
+				Eventually(session.Err, "5s").Should(gbytes.Say("Error connecting.*Will retry in 4 seconds"))
 
 				Expect(session.Wait("20s")).To(gexec.Exit(1))
 			})

--- a/syslog/drainer.go
+++ b/syslog/drainer.go
@@ -26,8 +26,6 @@ type Drainer interface {
 	Drain(line string, tag string) error
 }
 
-const ServerPollingInterval = 5 * time.Second
-
 type drainer struct {
 	conn           net.Conn
 	dialFunction   func() (net.Conn, error)
@@ -173,7 +171,9 @@ func (d *drainer) resetAttempts() {
 
 func (d *drainer) incrementAttempts() {
 	d.connAttempts++
-	d.sleepSeconds = d.sleepSeconds << 1
+	if d.maxRetries > 0 {
+		d.sleepSeconds = d.sleepSeconds << 1
+	}
 }
 
 func (d *drainer) ensureConnection() {

--- a/syslog/drainer.go
+++ b/syslog/drainer.go
@@ -171,7 +171,7 @@ func (d *drainer) resetAttempts() {
 
 func (d *drainer) incrementAttempts() {
 	d.connAttempts++
-	if d.maxRetries > 0 {
+	if d.maxRetries > 0 && d.sleepSeconds < 60 {
 		d.sleepSeconds = d.sleepSeconds << 1
 	}
 }


### PR DESCRIPTION
# Description

- In 5f3e237fd2cfcd3a763bcb0c1a3c014e7b9656d3 we added a backoff up to a configurable number of retries.
- When this number of retries is unset we could end up sleeping for a very long time before reconnection attempts.
- Instead preserve the previous behaviour of sleeping for a fixed 1 second interval between reconnection attempts when the max retries is unset.
- Remove ServerPollingInterval const that was only in use by the tests.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [ ] Unit tests
- [X] Integration tests
- [ ] Acceptance tests

## Checklist:

- [X] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [X] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
