### PR TITLE
feat: Update the used Go version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ _testmain.go
 
 /config.local.yml
 /*.txt
+
+# Idea config folder
+.idea

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Any new lines written to `app1/stdout.log` and `app1/stderr.log` get sent to sys
 
 If `log_filename` is set to `true` then the filename is included in the tag. For example, new lines written to `app1/stdout.log` get sent to syslog tagged as `app1/stdout.log`.
 
-Currently the priority and facility are hardcoded to `INFO` and `user`.
+Currently, the priority and facility are hardcoded to `INFO` and `user`.
 
 ## Installation
 

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,8 @@
 module code.cloudfoundry.org/blackbox
 
-go 1.21
-toolchain go1.22.5
+go 1.22.0
+
+toolchain go1.22.9
 
 require (
 	code.cloudfoundry.org/go-loggregator/v9 v9.2.1


### PR DESCRIPTION
# Description

The following change upgrades the used Go version. 

**Background:**
Go 1.21 is no longer [supported](https://endoflife.date/go) and we have problems with the different toolchain version within our security scans.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Testing performed?

- [x] Integration tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [x] I have made corresponding changes to the documentation
